### PR TITLE
Fix missing trait imports in src-tauri

### DIFF
--- a/src-tauri/src/callbacks.rs
+++ b/src-tauri/src/callbacks.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::Result;
 use jj_lib::{git::RemoteCallbacks, repo::MutableRepo};
-use tauri::{Manager, Window};
+use tauri::{Emitter, Manager, Window};
 
 use crate::{
     messages::{InputField, InputRequest},

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,7 +21,7 @@ use jj_cli::config::ConfigSource;
 use log::LevelFilter;
 use tauri::menu::Menu;
 use tauri::{ipc::InvokeError, Manager};
-use tauri::{State, Window, WindowEvent, Wry};
+use tauri::{Emitter, Listener, State, Window, WindowEvent, Wry};
 use tauri_plugin_window_state::StateFlags;
 
 use messages::{

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Context, Result};
 use tauri::menu::AboutMetadata;
 use tauri::{
     menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu},
-    AppHandle, Manager, Window, Wry,
+    AppHandle, Emitter, Manager, Window, Wry,
 };
 use tauri_plugin_dialog::DialogExt;
 


### PR DESCRIPTION
Without these I got errors like the following trying to run `npm build tauri build` on Linux:
```
error[E0599]: no method named `emit` found for struct `tauri::Window` in the current scope
   --> src/callbacks.rs:86:22
    |
86  |         match self.0.emit(
    |               -------^^^^
    |
   ::: /home/david/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-2.0.0-rc.5/src/lib.rs:892:6
    |
892 |   fn emit<S: Serialize + Clone>(&self, event: &str, payload: S) -...
    |      ---- the method is available for `tauri::Window` here
    |
    = help: items from traits can only be used if the trait is in scope
help: there is a method `emit_to` with a similar name, but with different arguments
   --> /home/david/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-2.0.0-rc.5/src/lib.rs:916:3
    |
916 | /   fn emit_to<I, S>(&self, target: I, event: &str, payload: S) -...
917 | |   where
918 | |     I: Into<EventTarget>,
919 | |     S: Serialize + Clone;
    | |_________________________^
help: trait `Emitter` which provides `emit` is implemented but not in scope; perhaps you want to import it
    |
4   + use tauri::Emitter;
    |
```