### PR TITLE
Allow saving a commit description with (Cmd/Ctrl)+Enter

### DIFF
--- a/src/RevisionPane.svelte
+++ b/src/RevisionPane.svelte
@@ -20,7 +20,14 @@
     const CONTEXT = 3;
 
     let mutator = new RevisionMutator(rev.header);
-    let fullDescription = rev.header.description.lines.join("\n");
+
+    const currentDescription = rev.header.description.lines.join("\n");
+    let fullDescription = currentDescription;
+    $: descriptionChanged = fullDescription !== currentDescription;
+    function updateDescription() {
+        mutator.onDescribe(fullDescription, resetAuthor);
+    }
+
     let resetAuthor = false;
 
     let unresolvedConflicts = rev.conflicts.filter(
@@ -123,7 +130,12 @@
             disabled={rev.header.is_immutable}
             bind:value={fullDescription}
             on:dragenter={dragOverWidget}
-            on:dragover={dragOverWidget} />
+            on:dragover={dragOverWidget}
+            on:keypress={(ev) => {
+                if (descriptionChanged && ev.key === "Enter" && (ev.metaKey || ev.ctrlKey)) {
+                    updateDescription();
+                }
+            }} />
 
         <div class="signature-commands">
             <span>Author:</span>
@@ -133,7 +145,7 @@
             <ActionWidget
                 tip="set commit message"
                 onClick={() => mutator.onDescribe(fullDescription, resetAuthor)}
-                disabled={rev.header.is_immutable}>
+                disabled={rev.header.is_immutable || !descriptionChanged}>
                 <Icon name="file-text" /> Describe
             </ActionWidget>
         </div>


### PR DESCRIPTION
As discussed in https://github.com/gulbanana/gg/discussions/16

This keeps track of the original description so we only show the Describe button as enabled if there is actually a change to save, giving some visual feedback.

I didn't try to distinguish between platforms for choosing between `.metaKey` and `.ctrlKey`. Let me know if you think we should be more precise.

---

This recording shows me deleting the initially entered text (making the button become disabled because there are no changes to save), then finally typing something and hitting Cmd+Enter to save.

https://github.com/user-attachments/assets/4f47471d-bf2b-4edf-b5a3-b6eb1bbd9a3c

