### PR TITLE
Branch name input tweaks

### DIFF
--- a/src/shell/InputDialog.svelte
+++ b/src/shell/InputDialog.svelte
@@ -63,7 +63,7 @@
         {:else if field.label == "Password"}
             <input id="field-{field.label}" type="password" />
         {:else}
-            <input id="field-{field.label}" type="text" />
+            <input id="field-{field.label}" type="text" autoCapitalize="off" autoCorrect="off" />
         {/if}
     {/each}
     <svelte:fragment slot="commands">

--- a/src/shell/InputDialog.svelte
+++ b/src/shell/InputDialog.svelte
@@ -83,6 +83,6 @@
     }
 
     :last-of-type {
-        margin-bottom: 1em;
+        margin: 1em 0;
     }
 </style>


### PR DESCRIPTION
On macOS the default auto-capitalization is very aggressive (see https://github.com/tauri-apps/tauri/discussions/7635)

I also tweaked the styles so the input doesn't jump when you start typing.

https://github.com/user-attachments/assets/9abe943d-56b3-4dd8-a80d-68a1bee37a41

https://github.com/user-attachments/assets/54247ec4-1001-4cba-a80a-f699902cacaa



