### PR TITLE
fix: On Webkit (macos and linux), horizontal scrollbars in diffs are too tall.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@ Known Issues
 * "Open..." menu command sometimes opens multiple dialogues.
 * Mutations can fail due to ambiguity when there are other writers; this should update the UI. Maybe a special From impl for resolve_change.
 * Windows codesigning will break in August 2024; the CI needs a new approach.
-* On Webkit (macos and linux), horizontal scrollbars in diffs are too tall. 
 * Visual issues on Xubuntu 22.04:
   - menu leaves a white background when there's no repo loaded - no xdamage maybe?
   - there's a weird bullet (looks like an uncoloured rev icon) in the sig area

--- a/src/RevisionPane.svelte
+++ b/src/RevisionPane.svelte
@@ -320,6 +320,7 @@
 
     .change::-webkit-scrollbar {
         width: 6px;
+        height: 6px;
     }
 
     .change::-webkit-scrollbar-thumb {


### PR DESCRIPTION
seems like the fix was to just manually specifying the height alongside the width!

tested on MacOS only

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/a6ab5b68-5b71-4af0-ada9-8dd4c1dd142b" />
