### PR TITLE
fix behave of Ctrl+Enter

### DIFF
--- a/src/RevisionPane.svelte
+++ b/src/RevisionPane.svelte
@@ -131,7 +131,7 @@
             bind:value={fullDescription}
             on:dragenter={dragOverWidget}
             on:dragover={dragOverWidget}
-            on:keypress={(ev) => {
+            on:keydown={(ev) => {
                 if (descriptionChanged && ev.key === "Enter" && (ev.metaKey || ev.ctrlKey)) {
                     updateDescription();
                 }


### PR DESCRIPTION
On the win11 , when editing in the describe window, `Ctrl + Enter` doesn't seem to confirm properly.  
![PixPin_2025-05-27_23-47-14](https://github.com/user-attachments/assets/05ca022a-4c6f-496d-b465-51a881864a2f)

This PR fixes the issue.  

