### PR TITLE
change debug port form 1420 to a more universal port

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "identifier": "au.gulbanana.gg",
   "build": {
     "beforeDevCommand": "npm run dev",
-    "devUrl": "http://localhost:1420",
+    "devUrl": "http://localhost:6973",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig(async () => ({
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
-    port: 1420,
+    port: 6973,
     strictPort: true,
     watch: {
       // 3. tell vite to ignore watching `src-tauri`


### PR DESCRIPTION
In Windows, if you have enabled Hyper-V or Docker or something, which require dynamic port allocation, the system will automatically reserve some lower port numbers. To ensure a smoother debugging experience, it might be appropriate to update to a higher port number instead. : )  

Command: `netsh interface ipv4 show excludedportrange protocol=tcp`  
Output:  
![image](https://github.com/user-attachments/assets/3bd60663-222e-4085-b647-98cc2b176a78)