### PR TITLE
fix highlight flickering when dragging change label onto hash

### DIFF
--- a/src/controls/IdSpan.svelte
+++ b/src/controls/IdSpan.svelte
@@ -14,8 +14,7 @@
 
 <style>
     .id {
-        pointer-events: auto;
-        user-select: text;
+        pointer-events: none;
         color: var(--ctp-subtext1);
         font-family: var(--stack-code);
     }

--- a/src/objects/RevisionObject.svelte
+++ b/src/objects/RevisionObject.svelte
@@ -102,6 +102,7 @@
 
 <style>
     .layout {
+        pointer-events: auto;
         /* layout summary components along a text line */
         width: 100%;
         height: 30px;


### PR DESCRIPTION

Previously, in the change label functionality, the event handling logic for `IdSpan` and other parts were separated. This caused abnormal behavior when dragging a change label onto another label's hash, as shown in the screenshot below:  
![PixPin_2025-05-30_21-32-17](https://github.com/user-attachments/assets/1a244da1-7ce9-4de3-88aa-c06cf4254d93)  

Now we've modified the implementation to let the label handle all events instead of the hash. As a result, the drag-and-drop highlighting for labels works correctly:  
![PixPin_2025-05-30_21-35-34](https://github.com/user-attachments/assets/a44492d5-6099-44e2-9800-2cd09aa653fe)  
