### PR TITLE
enables ID to be copied by clicking

### DIFF
--- a/src/RevisionPane.svelte
+++ b/src/RevisionPane.svelte
@@ -101,7 +101,8 @@
 <Pane>
     <h2 slot="header" class="header">
         <span class="title">
-            <IdSpan id={rev.header.id.change} /> | <IdSpan id={rev.header.id.commit} />
+            <IdSpan id={rev.header.id.change} clickable={true} />
+            | <IdSpan id={rev.header.id.commit} clickable={true} />
             {#if rev.header.is_working_copy}
                 | Working copy
             {/if}

--- a/src/controls/IdSpan.svelte
+++ b/src/controls/IdSpan.svelte
@@ -4,19 +4,61 @@
     import { currentTarget } from "../stores";
     export let id: ChangeId | CommitId;
     export let pronoun: boolean = false;
+    export let clickable: boolean = false;
 
     let suffix = id.rest.substring(0, 8 - id.prefix.length);
+
+    async function copyId() {
+        const shortestId = id.prefix + suffix.substring(0, 2);
+        try {
+            await navigator.clipboard.writeText(shortestId);
+        } catch (err) {
+            console.error("Failed to copy to clipboard:", err);
+        }
+    }
+
+    $: isClickable = clickable && !pronoun && $currentTarget?.type != "Repository";
 </script>
 
-<span class="id" class:pronoun={pronoun || $currentTarget?.type == "Repository"}>
+<button
+    class="id"
+    class:pronoun={pronoun || $currentTarget?.type == "Repository"}
+    class:clickable={isClickable}
+    disabled={!isClickable}
+    on:click={copyId}
+    title={isClickable ? "Click to copy ID" : ""}>
     <span class="prefix {id.type}">{id.prefix}</span>{suffix}
-</span>
+</button>
 
 <style>
     .id {
-        pointer-events: none;
         color: var(--ctp-subtext1);
         font-family: var(--stack-code);
+
+        /* reset button style, make it look like text */
+        background: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        font: inherit;
+        cursor: inherit;
+    }
+
+    .id:disabled {
+        pointer-events: none;
+    }
+
+    .id.clickable {
+        pointer-events: auto;
+        cursor: pointer;
+    }
+
+    .id.clickable:hover {
+        background-color: var(--ctp-surface1);
+    }
+
+    .id.clickable:active {
+        background-color: var(--ctp-surface2);
     }
 
     .ChangeId {


### PR DESCRIPTION
Users can now quickly copy Change/Commit ID by clicking on it in the top-right corner. To ensure CLI command history remains identifiable even after a certain period, the copied text follows the format: `shortest prefix + last two characters`.  

Demo:  
![PixPin_2025-06-21_11-24-30](https://github.com/user-attachments/assets/be5735c9-b77e-4ce1-9542-96e52b66a40c)  
