### PR TITLE
Swap squash and restore icons

### DIFF
--- a/src/RevisionPane.svelte
+++ b/src/RevisionPane.svelte
@@ -170,13 +170,13 @@
                     tip="move all changes to parent"
                     onClick={mutator.onSquash}
                     disabled={rev.header.is_immutable || rev.header.parent_ids.length != 1}>
-                    <Icon name="upload" /> Squash
+                    <Icon name="download" /> Squash
                 </ActionWidget>
                 <ActionWidget
                     tip="copy all changes from parent"
                     onClick={mutator.onRestore}
                     disabled={rev.header.is_immutable || rev.header.parent_ids.length != 1}>
-                    <Icon name="download" /> Restore
+                    <Icon name="upload" /> Restore
                 </ActionWidget>
             </div>
 


### PR DESCRIPTION
In jj, squash pushes changes DOWN, and restore pulls originals UP (as can be seen on the left-side graph), synchronize icons with this representation.