### PR TITLE
use from_utf8_lossy to prevent invalid utf-8 sequence errors

### DIFF
--- a/src-tauri/src/worker/queries.rs
+++ b/src-tauri/src/worker/queries.rs
@@ -532,7 +532,7 @@ fn get_unified_hunks(
                 }
             }
 
-            lines.push(std::str::from_utf8(&formatter)?.into());
+            lines.push(String::from_utf8_lossy(&formatter).into_owned());
         }
 
         hunks.push(ChangeHunk {


### PR DESCRIPTION
This fixes errors noted in https://github.com/gulbanana/gg/discussions/28