### PR TITLE
Avoid an unused code warning when building with the `gui` feature on macOS.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 mod callbacks;
 mod config;
 mod handler;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(feature = "gui")))]
 mod macos;
 mod menu;
 mod messages;


### PR DESCRIPTION


In theory it's possible to put the `cfg` inside `macos.rs`, but it would involve placing it everywhere throughout. So this is simpler for now.