### PR TITLE
stop log pane descriptions from truncating early

### DIFF
--- a/app/objects/RevisionObject.svelte
+++ b/app/objects/RevisionObject.svelte
@@ -190,7 +190,7 @@
     @media (width >= 1680px) {
         .layout {
             grid-template-areas: ". desc refs email";
-            grid-template-columns: auto auto 1fr auto;
+            grid-template-columns: auto 1fr auto auto;
             gap: 9px;
         }
 


### PR DESCRIPTION
On macOS the revision list in its wide layout is truncating revision descriptions even when they would have plenty of space to be displayed. My hypothesis is that WebKit is not recalculating the width of the `auto` sized grid cell when its content changes. If a row has a short description, and then gets updated to have a long description, the longer description gets truncated instead of widening the cell, even if there is space for the cell to grow into. The list being virtualized is probably producing the circumstances for this behaviour to occur more often than it otherwise would.

This change puts the wide layout in line with the narrow one: the description column gets the `1fr` track size and the rest are `auto`. Empirically this keeps everything behaving as before except now Apple browsers give the description all the space available to it. The "priority" of what gets hidden first if everything does not fit remains unchanged: id is shown always, then refs, then author if there is space left still and then description takes the rest of available space.

Below is a screen recording of this behaviour after this change (which as far as I can tell is same as before this change on all the platforms I am able to test this on). Only difference to before is lack of the funky truncation on Apple browsers.

Tested on macOS & Windows, in the native GUI and in Safari, Firefox and Chrome.



https://github.com/user-attachments/assets/86b36ec9-e66e-49e7-804e-301a0e850d54









Resolves #110.