### PR TITLE
make two-pane separator draggable

### DIFF
--- a/app/App.svelte
+++ b/app/App.svelte
@@ -8,6 +8,40 @@
     import SetSpan from "./controls/SetSpan.svelte";
 
     let route = parseRoute();
+    let leftFraction = 0.5; // 50/50 split
+    let isDragging = false;
+
+    function onMouseDown(e: MouseEvent) {
+        e.preventDefault();
+        isDragging = true;
+        document.addEventListener("mousemove", onMouseMove);
+        document.addEventListener("mouseup", onMouseUp);
+    }
+
+    function onMouseMove(e: MouseEvent) {
+        if (!isDragging) return;
+
+        let container = document.querySelector(".two-pane") as HTMLElement;
+        if (!container) return;
+
+        let rect = container.getBoundingClientRect();
+        let containerWidth = rect.width;
+        let mouseX = e.clientX - rect.left;
+
+        // Clamp between 20% and 80% of container width
+        let minWidth = containerWidth * 0.05;
+        let maxWidth = containerWidth * 0.95;
+        let clampedX = Math.max(minWidth, Math.min(maxWidth, mouseX));
+
+        // Calculate left pane fraction (convert pixel position to fraction)
+        leftFraction = clampedX / (containerWidth - 4); // 4px is separator width
+    }
+
+    function onMouseUp() {
+        isDragging = false;
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+    }
 </script>
 
 <Shell revsetOverride={route.type === "revision" ? route.revset : null}
@@ -38,13 +72,13 @@
             </Pane>
         </BoundQuery>
     {:else}
-        <div class="two-pane">
+        <div class="two-pane" style="grid-template-columns: {leftFraction}fr 4px {1 - leftFraction}fr;">
             {#key workspace.absolute_path}
                 <LogPane query_choices={workspace.query_choices}
                          latest_query={workspace.latest_query} />
             {/key}
 
-            <div class="separator"></div>
+            <div class="separator" on:mousedown={onMouseDown} class:dragging={isDragging}></div>
 
             <BoundQuery query={selection} let:data>
                 {#if data.type == "Detail"}
@@ -72,12 +106,24 @@
 <style>
     .two-pane {
         display: grid;
-        grid-template-columns: 1fr 3px 1fr;
         height: 100%;
         overflow: hidden;
     }
 
     .separator {
         background: var(--ctp-overlay0);
+        cursor: col-resize;
+        user-select: none;
+        pointer-events: auto;
+        width: 4px;
+        margin-left: -2.5px;
+    }
+
+    .separator:hover {
+        background: var(--ctp-surface0);
+    }
+
+    .separator.dragging {
+        background: var(--ctp-blue);
     }
 </style>


### PR DESCRIPTION
- Add drag handler to resize left/right panes dynamically
- Separator is 4px wide with -2.5px margin for easy grabbing
- Separator changes color on hover (surface0) and while dragging (blue)
- Resize is clamped between 5% and 95% of container width
- Grid columns update in real-time based on mouse movement
- Smooth interaction with col-resize cursor

<img width="1275" height="643" alt="Screenshot 2026-04-13 at 11 06 32 AM" src="https://github.com/user-attachments/assets/e1f3517f-c61b-4ea2-aed8-b7de8cec173f" />
