### PR TITLE
Improve rendering of conflicts in changes panel

### DIFF
--- a/app/RevisionPane.svelte
+++ b/app/RevisionPane.svelte
@@ -124,6 +124,39 @@
             return null;
         }
     }
+
+    interface DiffSegment {
+        conflict: boolean;
+        lines: string[];
+    }
+
+    function segmentHunk(hunkLines: string[]): DiffSegment[] {
+        let segments: DiffSegment[] = [];
+        let current: DiffSegment = { conflict: false, lines: [] };
+
+        for (let line of hunkLines) {
+            if (line.startsWith(" <<<<<<< ")) {
+                if (current.lines.length > 0) segments.push(current);
+                current = { conflict: true, lines: [line] };
+            } else if (line.startsWith(" >>>>>>> ")) {
+                current.lines.push(line);
+                segments.push(current);
+                current = { conflict: false, lines: [] };
+            } else {
+                current.lines.push(line);
+            }
+        }
+        if (current.lines.length > 0) segments.push(current);
+        return segments;
+    }
+
+    function isConflictMarker(line: string): boolean {
+        return (
+            line.startsWith(" <<<<<<< ") ||
+            line.startsWith(" >>>>>>> ") ||
+            line.startsWith(" +++++++ ")
+        );
+    }
 </script>
 
 <Pane>
@@ -260,12 +293,16 @@
                         {#if $changeSelectEvent?.path?.repo_path === change.path.repo_path}
                             <div class="change" style="--lines: {minLines(change)}" tabindex="-1">
                                 {#each change.hunks as hunk}
+                                    {#if !change.has_conflict}
                                     <div class="hunk">
                                         <HunkObject header={singleton ? newest : null} path={change.path} {hunk} />
                                     </div>
-                                    <pre class="diff">{#each hunk.lines.lines as line}<span class={lineColour(line)}
+                                    {/if}
+                                    <pre class="diff">{#each segmentHunk(hunk.lines.lines) as segment}{#if segment.conflict}<span class="conflict-region">{#each segment.lines as line}{#if isConflictMarker(line)}<span class="conflict-marker">{line}</span>{:else}<span class={lineColour(line)}
                                                 >{line}</span
-                                            >{/each}</pre>
+                                            >{/if}{/each}</span>{:else}{#each segment.lines as line}<span class={lineColour(line)}
+                                                >{line}</span
+                                            >{/each}{/if}{/each}</pre>
                                 {/each}
                             </div>
                         {/if}
@@ -455,6 +492,21 @@
 
     .remove {
         color: var(--ctp-red);
+    }
+
+    .conflict-region {
+        display: block;
+        background: repeating-linear-gradient(
+            120deg,
+            transparent 0px,
+            transparent 12px,
+            var(--ctp-surface0) 12px,
+            var(--ctp-surface0) 15px
+        );
+    }
+
+    .conflict-marker {
+        color: var(--ctp-overlay0);
     }
 
     .target {

--- a/src/worker/queries.rs
+++ b/src/worker/queries.rs
@@ -368,7 +368,7 @@ pub async fn query_revisions(ws: &WorkspaceSession<'_>, set: RevSet) -> Result<R
                             same_change: SameChange::Accept,
                         },
                     );
-                    let hunk = format_conflict_hunks(merge_result, &file.labels);
+                    let hunk = format_conflict_hunks(merge_result, &file.labels)?;
                     if !hunk.lines.lines.is_empty() {
                         conflicts.push(RevConflict {
                             path: formatted_path,
@@ -483,7 +483,7 @@ async fn format_tree_changes(
                             same_change: SameChange::Accept,
                         },
                     );
-                    vec![format_conflict_hunks(merge_result, &file.labels)]
+                    vec![format_conflict_hunks(merge_result, &file.labels)?]
                 }
                 other => {
                     let before_value = conflicts::materialize_tree_value(
@@ -590,7 +590,7 @@ async fn get_value_contents(path: &RepoPath, value: MaterializedTreeValue) -> Re
 
 /// render a conflict as a diff: base content as deletions, sides as additions,
 /// resolved hunks as context. each section is labeled with the conflict label.
-fn format_conflict_hunks(merge_result: MergeResult, labels: &ConflictLabels) -> ChangeHunk {
+fn format_conflict_hunks(merge_result: MergeResult, labels: &ConflictLabels) -> Result<ChangeHunk> {
     let mut lines = Vec::new();
 
     let hunks = match merge_result {
@@ -599,13 +599,13 @@ fn format_conflict_hunks(merge_result: MergeResult, labels: &ConflictLabels) -> 
                 lines.push(format!(" {line}\n"));
             }
             let len = lines.len();
-            return ChangeHunk {
+            return Ok(ChangeHunk {
                 location: ChangeLocation {
                     from_file: ChangeRange { start: 0, len },
                     to_file: ChangeRange { start: 0, len },
                 },
                 lines: MultilineString { lines },
-            };
+            });
         }
         MergeResult::Conflict(hunks) => hunks,
     };
@@ -623,6 +623,61 @@ fn format_conflict_hunks(merge_result: MergeResult, labels: &ConflictLabels) -> 
             }
         } else {
             conflict_idx += 1;
+
+            // when one side is empty (edit-vs-delete), show a diff between
+            // base and the non-empty side instead of the raw merge output
+            let adds: Vec<_> = hunk.adds().collect();
+            let removes: Vec<_> = hunk.removes().collect();
+            if removes.len() == 1 && adds.len() == 2 {
+                let empty_idx = adds.iter().position(|s| s.is_empty());
+                if let Some(empty_idx) = empty_idx {
+                    let other_idx = 1 - empty_idx;
+                    let deleted_label = labels.get_add(empty_idx).map_or_else(
+                        || format!("side {}", empty_idx + 1),
+                        |l| format!("side {} ({l})", empty_idx + 1),
+                    );
+                    let kept_label = labels.get_add(other_idx).map_or_else(
+                        || format!("side {}", other_idx + 1),
+                        |l| format!("side {} ({l})", other_idx + 1),
+                    );
+                    lines.push(format!(
+                        " <<<<<<< conflict {conflict_idx} of {num_conflicts} \
+                         — deleted by {deleted_label}\n"
+                    ));
+                    let base_content = removes[0];
+                    let side_content = adds[other_idx];
+                    let diff_hunks = get_unified_hunks(3, base_content.as_ref(), side_content.as_ref())?;
+                    if diff_hunks.is_empty() {
+                        // base and kept side are identical
+                        lines.push(format!(" +++++++ {kept_label} (unchanged)\n"));
+                        for line in String::from_utf8_lossy(side_content).lines() {
+                            lines.push(format!(" {line}\n"));
+                            from_len += 1;
+                            to_len += 1;
+                        }
+                    } else {
+                        lines.push(format!(" +++++++ {kept_label}\n"));
+                        for diff_hunk in &diff_hunks {
+                            for line in &diff_hunk.lines.lines {
+                                lines.push(line.clone());
+                                if line.starts_with('-') {
+                                    from_len += 1;
+                                } else if line.starts_with('+') {
+                                    to_len += 1;
+                                } else {
+                                    from_len += 1;
+                                    to_len += 1;
+                                }
+                            }
+                        }
+                    }
+                    lines.push(format!(
+                        " >>>>>>> conflict {conflict_idx} of {num_conflicts}\n"
+                    ));
+                    continue;
+                }
+            }
+
             lines.push(format!(" <<<<<<< conflict {conflict_idx} of {num_conflicts}\n"));
             for base in hunk.removes() {
                 for line in String::from_utf8_lossy(base).lines() {
@@ -645,7 +700,7 @@ fn format_conflict_hunks(merge_result: MergeResult, labels: &ConflictLabels) -> 
         }
     }
 
-    ChangeHunk {
+    Ok(ChangeHunk {
         location: ChangeLocation {
             from_file: ChangeRange {
                 start: 0,
@@ -657,7 +712,7 @@ fn format_conflict_hunks(merge_result: MergeResult, labels: &ConflictLabels) -> 
             },
         },
         lines: MultilineString { lines },
-    }
+    })
 }
 
 fn get_unified_hunks(

--- a/src/worker/queries.rs
+++ b/src/worker/queries.rs
@@ -25,7 +25,7 @@ use jj_lib::{
         ContentDiff, DiffHunk, DiffHunkKind, find_line_ranges,
     },
     diff_presentation::LineCompareMode,
-    files::FileMergeHunkLevel,
+    files::{self, FileMergeHunkLevel, MergeResult},
     graph::{GraphEdge, GraphEdgeType, TopoGroupedGraphIterator},
     matchers::EverythingMatcher,
     merge::{Diff, SameChange},
@@ -337,11 +337,21 @@ pub async fn query_revisions(ws: &WorkspaceSession<'_>, set: RevSet) -> Result<R
     let conflict_labels = Diff::new(parent_tree.labels(), final_tree.labels());
     format_tree_changes(ws, &mut changes, tree_diff, conflict_labels).await?;
 
+    // find inherited conflicts: files conflicted in final_tree but unchanged relative to parent.
+    // conflicted changes with empty hunks (tree value differs but materialized content is identical)
+    // are also handled here, since they have nothing useful to display as a diff.
+    changes.retain(|c| !c.has_conflict || !c.hunks.is_empty());
+    let changed_paths: HashSet<&str> = changes.iter().map(|c| c.path.repo_path.as_str()).collect();
     let mut conflicts = Vec::new();
     for (path, entry) in final_tree.entries() {
         if let Ok(entry) = entry
             && !entry.is_resolved()
         {
+            let formatted_path = ws.format_path(path.clone())?;
+            if changed_paths.contains(formatted_path.repo_path.as_str()) {
+                continue;
+            }
+
             match conflicts::materialize_tree_value(
                 ws.repo().store(),
                 &path,
@@ -351,24 +361,17 @@ pub async fn query_revisions(ws: &WorkspaceSession<'_>, set: RevSet) -> Result<R
             .await?
             {
                 MaterializedTreeValue::FileConflict(file) => {
-                    let mut hunk_content = vec![];
-                    conflicts::materialize_merge_result(
+                    let merge_result = files::merge_hunks(
                         &file.contents,
-                        &file.labels,
-                        &mut hunk_content,
-                        &ConflictMaterializeOptions {
-                            marker_style: ConflictMarkerStyle::Git,
-                            marker_len: None,
-                            merge: MergeOptions {
-                                hunk_level: FileMergeHunkLevel::Line,
-                                same_change: SameChange::Accept,
-                            },
+                        &MergeOptions {
+                            hunk_level: FileMergeHunkLevel::Line,
+                            same_change: SameChange::Accept,
                         },
-                    )?;
-                    let mut hunks = get_unified_hunks(3, &hunk_content, &[])?;
-                    if let Some(hunk) = hunks.pop() {
+                    );
+                    let hunk = format_conflict_hunks(merge_result, &file.labels);
+                    if !hunk.lines.lines.is_empty() {
                         conflicts.push(RevConflict {
-                            path: ws.format_path(path)?,
+                            path: formatted_path,
                             hunk,
                         });
                     }
@@ -379,12 +382,6 @@ pub async fn query_revisions(ws: &WorkspaceSession<'_>, set: RevSet) -> Result<R
             }
         }
     }
-
-    let conflicted_paths: HashSet<String> = conflicts
-        .iter()
-        .map(|conflict| conflict.path.repo_path.clone())
-        .collect();
-    changes.retain(|change| !conflicted_paths.contains(&change.path.repo_path));
 
     // details for each revision in the set
     let mut headers = Vec::new();
@@ -469,13 +466,52 @@ async fn format_tree_changes(
 
         let has_conflict = !after.is_resolved();
 
-        let before_future =
-            conflicts::materialize_tree_value(store, &path, before.clone(), conflict_labels.before);
-        let after_future =
-            conflicts::materialize_tree_value(store, &path, after.clone(), conflict_labels.after);
-        let (before_value, after_value) = try_join!(before_future, after_future)?;
-
-        let hunks = get_value_hunks(3, &path, before_value, after_value).await?;
+        let hunks = if has_conflict {
+            let after_value = conflicts::materialize_tree_value(
+                store,
+                &path,
+                after.clone(),
+                conflict_labels.after,
+            )
+            .await?;
+            match after_value {
+                MaterializedTreeValue::FileConflict(file) => {
+                    let merge_result = files::merge_hunks(
+                        &file.contents,
+                        &MergeOptions {
+                            hunk_level: FileMergeHunkLevel::Line,
+                            same_change: SameChange::Accept,
+                        },
+                    );
+                    vec![format_conflict_hunks(merge_result, &file.labels)]
+                }
+                other => {
+                    let before_value = conflicts::materialize_tree_value(
+                        store,
+                        &path,
+                        before.clone(),
+                        conflict_labels.before,
+                    )
+                    .await?;
+                    get_value_hunks(3, &path, before_value, other).await?
+                }
+            }
+        } else {
+            let before_future = conflicts::materialize_tree_value(
+                store,
+                &path,
+                before.clone(),
+                conflict_labels.before,
+            );
+            let after_future = conflicts::materialize_tree_value(
+                store,
+                &path,
+                after.clone(),
+                conflict_labels.after,
+            );
+            let (before_value, after_value) = try_join!(before_future, after_future)?;
+            get_value_hunks(3, &path, before_value, after_value).await?
+        };
 
         changes.push(RevChange {
             path: ws.format_path(path)?,
@@ -549,6 +585,78 @@ async fn get_value_contents(path: &RepoPath, value: MaterializedTreeValue) -> Re
         }
         MaterializedTreeValue::Tree(_) => Err(anyhow!("Unexpected tree in diff at path {path:?}")),
         MaterializedTreeValue::AccessDenied(error) => Err(anyhow!(error)),
+    }
+}
+
+/// render a conflict as a diff: base content as deletions, sides as additions,
+/// resolved hunks as context. each section is labeled with the conflict label.
+fn format_conflict_hunks(merge_result: MergeResult, labels: &ConflictLabels) -> ChangeHunk {
+    let mut lines = Vec::new();
+
+    let hunks = match merge_result {
+        MergeResult::Resolved(content) => {
+            for line in String::from_utf8_lossy(&content).lines() {
+                lines.push(format!(" {line}\n"));
+            }
+            let len = lines.len();
+            return ChangeHunk {
+                location: ChangeLocation {
+                    from_file: ChangeRange { start: 0, len },
+                    to_file: ChangeRange { start: 0, len },
+                },
+                lines: MultilineString { lines },
+            };
+        }
+        MergeResult::Conflict(hunks) => hunks,
+    };
+
+    let num_conflicts = hunks.iter().filter(|h| !h.is_resolved()).count();
+    let mut conflict_idx = 0;
+    let mut from_len = 0;
+    let mut to_len = 0;
+    for hunk in &hunks {
+        if let Some(content) = hunk.resolve_trivial(SameChange::Accept) {
+            for line in String::from_utf8_lossy(content).lines() {
+                lines.push(format!(" {line}\n"));
+                from_len += 1;
+                to_len += 1;
+            }
+        } else {
+            conflict_idx += 1;
+            lines.push(format!(" <<<<<<< conflict {conflict_idx} of {num_conflicts}\n"));
+            for base in hunk.removes() {
+                for line in String::from_utf8_lossy(base).lines() {
+                    lines.push(format!("-{line}\n"));
+                    from_len += 1;
+                }
+            }
+            for (i, side) in hunk.adds().enumerate() {
+                let label = labels.get_add(i).map_or_else(
+                    || format!(" +++++++ side {}\n", i + 1),
+                    |l| format!(" +++++++ side {} ({l})\n", i + 1),
+                );
+                lines.push(label);
+                for line in String::from_utf8_lossy(side).lines() {
+                    lines.push(format!("+{line}\n"));
+                    to_len += 1;
+                }
+            }
+            lines.push(format!(" >>>>>>> conflict {conflict_idx} of {num_conflicts}\n"));
+        }
+    }
+
+    ChangeHunk {
+        location: ChangeLocation {
+            from_file: ChangeRange {
+                start: 0,
+                len: from_len,
+            },
+            to_file: ChangeRange {
+                start: 0,
+                len: to_len,
+            },
+        },
+        lines: MultilineString { lines },
     }
 }
 

--- a/src/worker/tests/queries.rs
+++ b/src/worker/tests/queries.rs
@@ -137,17 +137,18 @@ async fn revision_with_conflict() -> Result<()> {
     // The conflicts field should contain the conflict info from the final tree
     assert!(!conflicts.is_empty(), "Expected conflicts to be non-empty");
 
-    // The conflict hunks should contain conflict markers (<<<<<<< and >>>>>>>)
-    let conflict_lines: String = conflicts
+    // The conflict hunks should show base as deletions and sides as additions
+    let conflict_lines: Vec<&str> = conflicts
         .iter()
         .flat_map(|c| &c.hunk.lines.lines)
-        .cloned()
-        .collect::<Vec<_>>()
-        .join("\n");
+        .map(|l| l.as_str())
+        .collect();
 
+    let has_removals = conflict_lines.iter().any(|l| l.starts_with('-'));
+    let has_additions = conflict_lines.iter().any(|l| l.starts_with('+'));
     assert!(
-        conflict_lines.contains("<<<<<<<") && conflict_lines.contains(">>>>>>>"),
-        "Expected conflict markers in conflict hunks, got: {conflict_lines}"
+        has_removals && has_additions,
+        "Expected base deletions and side additions in conflict hunks, got: {conflict_lines:?}"
     );
 
     Ok(())
@@ -468,17 +469,18 @@ async fn inherited_conflict_persists() -> Result<()> {
         "Expected conflicts to be non-empty for inherited conflict"
     );
 
-    // The conflict markers should still be present
-    let conflict_lines: String = conflicts
+    // The conflict hunks should show base as deletions and sides as additions
+    let conflict_lines: Vec<&str> = conflicts
         .iter()
         .flat_map(|c| &c.hunk.lines.lines)
-        .cloned()
-        .collect::<Vec<_>>()
-        .join("\n");
+        .map(|l| l.as_str())
+        .collect();
 
+    let has_removals = conflict_lines.iter().any(|l| l.starts_with('-'));
+    let has_additions = conflict_lines.iter().any(|l| l.starts_with('+'));
     assert!(
-        conflict_lines.contains("<<<<<<<") && conflict_lines.contains(">>>>>>>"),
-        "Expected conflict markers in inherited conflict, got: {conflict_lines}"
+        has_removals && has_additions,
+        "Expected base deletions and side additions in inherited conflict, got: {conflict_lines:?}"
     );
 
     // There should be a change for the unrelated.txt file that was added
@@ -542,7 +544,7 @@ async fn range_through_inherited_conflict() -> Result<()> {
 mod conflict_chain_ranges {
     use super::*;
 
-    /// Range ending in a conflicted commit should show conflicts
+    /// Range ending in a conflicted commit should show the conflict in changes
     #[tokio::test]
     async fn range_ends_in_conflict() -> Result<()> {
         let repo = mkrepo();
@@ -561,7 +563,7 @@ mod conflict_chain_ranges {
         .await?;
 
         let RevsResult::Detail {
-            headers, conflicts, ..
+            headers, changes, ..
         } = result
         else {
             panic!("Expected RevsResult::Detail");
@@ -574,18 +576,18 @@ mod conflict_chain_ranges {
             "Final commit in range should have conflict"
         );
 
-        // Conflicts field reflects final tree state
+        // Conflict introduced within the range appears in changes with has_conflict flag
+        let conflict_change = changes
+            .iter()
+            .find(|c| c.path.repo_path.contains("conflict_chain"));
         assert!(
-            !conflicts.is_empty(),
-            "Range ending in conflicted commit should have non-empty conflicts"
+            conflict_change.is_some(),
+            "Expected change for conflict_chain.txt, got: {:?}",
+            changes.iter().map(|c| &c.path.repo_path).collect::<Vec<_>>()
         );
-
-        // Verify it's the conflict_chain.txt conflict
-        let conflict_paths: Vec<_> = conflicts.iter().map(|c| &c.path.repo_path).collect();
         assert!(
-            conflict_paths.iter().any(|p| p.contains("conflict_chain")),
-            "Expected conflict in conflict_chain.txt, got: {:?}",
-            conflict_paths
+            conflict_change.unwrap().has_conflict,
+            "Change for conflict_chain.txt should be marked as conflicted"
         );
 
         Ok(())


### PR DESCRIPTION
Conflicted files are being displayed as deletions in the changes panel. This issue was introduced by https://github.com/gulbanana/gg/commit/55d9b3f403495766234ae8e6466d121bfaa7f6c9, which discards the actual diff and leaves only the all-deletions conflict view.

Before:

<img width="813" height="819" alt="image" src="https://github.com/user-attachments/assets/6ea8477e-a8bd-4deb-a8fd-5aa1d555a669" />

After:

<img width="885" height="832" alt="image" src="https://github.com/user-attachments/assets/43d02527-99e7-4e40-a436-e0be7bbd721f" />



This PR also improves the rendering of delete-edit conflicts.

Before:

<img width="908" height="900" alt="image" src="https://github.com/user-attachments/assets/7522f6e6-7a98-443d-9dec-2513a7232b01" />

After:

<img width="884" height="1065" alt="image" src="https://github.com/user-attachments/assets/d64cec52-7def-4138-9ecd-6412891c6f76" />
