### PR TITLE
feat: add macOS Window menu listing open repositories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
     "NSApplication",
     "NSDocumentController",
     "NSImage",
+    "NSWindow",
 ] }
 
 [profile.dev]

--- a/src/gui/menu.rs
+++ b/src/gui/menu.rs
@@ -12,7 +12,11 @@ use tauri_plugin_dialog::{DialogExt, FilePath};
 use super::{AppState, handler};
 use gg_lib::messages::{Operand, RepoEvent, RevHeader, StoreRef};
 
-pub fn build_main(app_handle: &AppHandle, recent_items: &[String]) -> tauri::Result<Menu<Wry>> {
+pub fn build_main(
+    app_handle: &AppHandle,
+    recent_items: &[String],
+    open_windows: &[(String, String)],
+) -> tauri::Result<Menu<Wry>> {
     #[cfg(target_os = "macos")]
     let pkg_info = app_handle.package_info();
     #[cfg(target_os = "macos")]
@@ -169,6 +173,24 @@ pub fn build_main(app_handle: &AppHandle, recent_items: &[String]) -> tauri::Res
         ],
     )?;
 
+    #[cfg(target_os = "macos")]
+    let window_submenu = {
+        let submenu = Submenu::new(app_handle, "Window", true)?;
+        submenu.append(&PredefinedMenuItem::minimize(app_handle, None)?)?;
+        if !open_windows.is_empty() {
+            submenu.append(&PredefinedMenuItem::separator(app_handle)?)?;
+            for (label, display_name) in open_windows {
+                let id = format!("window:{label}");
+                if let Ok(item) =
+                    MenuItem::with_id(app_handle, id, display_name, true, None::<&str>)
+                {
+                    submenu.append(&item)?;
+                }
+            }
+        }
+        submenu
+    };
+
     let menu = Menu::with_items(
         app_handle,
         &[
@@ -191,14 +213,20 @@ pub fn build_main(app_handle: &AppHandle, recent_items: &[String]) -> tauri::Res
             &repo_menu,
             &revision_menu,
             &edit_menu,
+            #[cfg(target_os = "macos")]
+            &window_submenu,
         ],
     )?;
 
     Ok(menu)
 }
 
-pub fn rebuild_main(app_handle: &AppHandle, recent_items: Vec<String>) -> Result<()> {
-    let menu = build_main(app_handle, &recent_items)?;
+pub fn rebuild_main(
+    app_handle: &AppHandle,
+    recent_items: Vec<String>,
+    open_windows: &[(String, String)],
+) -> Result<()> {
+    let menu = build_main(app_handle, &recent_items, open_windows)?;
     app_handle.set_menu(menu)?;
     Ok(())
 }
@@ -602,14 +630,21 @@ pub fn handle_context(window: Window, ctx: Operand, ignore_immutable: bool) -> R
 
 pub fn handle_event(window: &Window, event: MenuEvent) -> Result<()> {
     log::debug!("handling event {event:?}");
+    let event_id = event.id.0.as_str();
 
     // we use a shared menu due to cleanup issues
     if !window.is_focused()? {
+        if let Some(window_id) = event_id.strip_prefix("window:") {
+            if let Some(w) = window.app_handle().get_webview_window(window_id) {
+                let _ = w.show();
+                let _ = w.set_focus();
+            }
+        }
         return Ok(());
     }
 
     let target = EventTarget::window(window.label());
-    match event.id.0.as_str() {
+    match event_id {
         "menu_repo_init" => repo_init(window),
         "menu_repo_clone" => repo_clone(window),
         "menu_repo_open" => repo_open(window),

--- a/src/gui/menu.rs
+++ b/src/gui/menu.rs
@@ -636,6 +636,12 @@ pub fn handle_event(window: &Window, event: MenuEvent) -> Result<()> {
     if !window.is_focused()? {
         if let Some(window_id) = event_id.strip_prefix("window:") {
             if let Some(w) = window.app_handle().get_webview_window(window_id) {
+                #[cfg(target_os = "macos")]
+                {
+                    crate::macos::remove_move_to_active_space(&w.as_ref().window());
+                    crate::macos::activate_app();
+                }
+
                 let _ = w.show();
                 let _ = w.set_focus();
             }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -42,15 +42,22 @@ struct AppState {
     settings: UserSettings,
     initial_ignore_immutable: bool,
     enable_askpass: bool,
+    recent_workspaces: Mutex<Vec<String>>,
 }
 
 impl AppState {
-    fn new(settings: UserSettings, initial_ignore_immutable: bool, enable_askpass: bool) -> Self {
+    fn new(
+        settings: UserSettings,
+        initial_ignore_immutable: bool,
+        enable_askpass: bool,
+        recent_workspaces: Vec<String>,
+    ) -> Self {
         Self {
             windows: Arc::new(Mutex::new(HashMap::new())),
             settings,
             initial_ignore_immutable,
             enable_askpass,
+            recent_workspaces: Mutex::new(recent_workspaces),
         }
     }
 }
@@ -65,6 +72,7 @@ struct WindowState {
     selection: Option<messages::RevSet>,
     has_workspace: bool,
     ignore_immutable: bool,
+    workspace_path: Option<String>,
 }
 
 impl AppState {
@@ -105,8 +113,37 @@ impl AppState {
             state.has_workspace = has_workspace;
         }
     }
-}
 
+    fn set_workspace_path(&self, window_label: &str, path: Option<String>) {
+        if let Some(state) = self
+            .windows
+            .lock()
+            .expect("state mutex poisoned")
+            .get_mut(window_label)
+        {
+            state.workspace_path = path;
+        }
+    }
+
+    fn window_entries(&self) -> Vec<(String, String)> {
+        let mut entries: Vec<(String, String)> = self
+            .windows
+            .lock()
+            .expect("state mutex poisoned")
+            .iter()
+            .filter_map(|(label, state)| {
+                let path = state.workspace_path.as_ref()?;
+                let name = std::path::Path::new(path)
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| path.clone());
+                Some((label.clone(), name))
+            })
+            .collect();
+        entries.sort_by(|a, b| a.1.cmp(&b.1));
+        entries
+    }
+}
 fn label_for_path(path: Option<&PathBuf>) -> String {
     let path = path
         .cloned()
@@ -128,6 +165,7 @@ fn resolve_set(
 
 pub fn run_gui(options: super::RunOptions) -> Result<()> {
     let recent_workspaces = options.settings.ui_recent_workspaces();
+    let initial_recent = recent_workspaces.clone();
 
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -214,11 +252,12 @@ pub fn run_gui(options: super::RunOptions) -> Result<()> {
             undo_operation,
             write_config_table,
         ])
-        .menu(move |handle| menu::build_main(handle, &recent_workspaces))
+        .menu(move |handle| menu::build_main(handle, &recent_workspaces, &[]))
         .manage(AppState::new(
             options.settings,
             options.ignore_immutable,
             options.enable_askpass,
+            initial_recent,
         ))
         .setup(move |app| {
             // after tauri initialises NSApplication, set the dock icon if we're running as CLI
@@ -878,6 +917,7 @@ pub fn try_create_window(app_handle: &AppHandle, workspace: Option<PathBuf>) -> 
             selection: None,
             has_workspace: false,
             ignore_immutable: initial_ignore_immutable,
+            workspace_path: None,
         },
     );
 
@@ -1032,6 +1072,7 @@ fn try_open_repository(window: &Window, cwd: Option<PathBuf>) -> Result<messages
 
             let workspace_path = absolute_path.0.clone();
             _ = window.set_title((String::from("GG - ") + workspace_path.as_str()).as_str());
+            app_state.set_workspace_path(window.label(), Some(workspace_path.clone()));
 
             // update config and jump lists - this can be slow
             if *track_recent_workspaces {
@@ -1039,16 +1080,33 @@ fn try_open_repository(window: &Window, cwd: Option<PathBuf>) -> Result<messages
                 thread::spawn(move || {
                     handler::nonfatal!(add_recent_workspaces(window, workspace_path));
                 });
+            } else {
+                rebuild_menu(window.app_handle());
             }
         }
         _ => {
             app_state.set_has_workspace(window.label(), false);
+            app_state.set_workspace_path(window.label(), None);
 
             let _ = window.set_title("GG - Gui for JJ");
+            rebuild_menu(window.app_handle());
         }
     }
 
     Ok(config)
+}
+
+fn rebuild_menu(app_handle: &AppHandle) {
+    let app_state = app_handle.state::<AppState>();
+    let recent = app_state.recent_workspaces.lock().unwrap().clone();
+    let open_windows = app_state.window_entries();
+    let handle = app_handle.clone();
+    let handle2 = handle.clone();
+    handle
+        .run_on_main_thread(move || {
+            handler::nonfatal!(menu::rebuild_main(&handle2, recent, &open_windows));
+        })
+        .ok();
 }
 
 fn try_mutate<T: Mutation + Send + Sync + 'static>(
@@ -1079,6 +1137,7 @@ fn handle_window_event(window: &Window, event: &WindowEvent) -> Result<()> {
         WindowEvent::Destroyed => {
             let app_state = window.state::<AppState>();
             app_state.windows.lock().unwrap().remove(window.label());
+            rebuild_menu(window.app_handle());
         }
         WindowEvent::Focused(true) => {
             log::debug!("window focused; notifying frontend");
@@ -1152,14 +1211,12 @@ fn add_recent_workspaces(window: Window, workspace_path: String) -> Result<()> {
             .ok();
     }
 
-    let app_handle = window.app_handle().clone();
-    let recent_for_menu = recent.clone();
-    let app_handle_inner = app_handle.clone();
-    app_handle
-        .run_on_main_thread(move || {
-            handler::nonfatal!(menu::rebuild_main(&app_handle_inner, recent_for_menu));
-        })
-        .ok();
+    {
+        let app_state = window.state::<AppState>();
+        *app_state.recent_workspaces.lock().unwrap() = recent.clone();
+    }
+
+    rebuild_menu(window.app_handle());
 
     session_tx.send(SessionEvent::WriteConfigArray {
         key: vec![

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2,6 +2,7 @@ mod handler;
 mod menu;
 #[cfg(target_os = "macos")]
 mod recent_items;
+mod single_instance;
 mod sink;
 
 use std::collections::HashMap;
@@ -163,6 +164,10 @@ fn resolve_set(
     rx.recv()?
 }
 
+pub fn try_forward_to_instance(workspace: Option<&PathBuf>) -> bool {
+    single_instance::try_forward(workspace)
+}
+
 pub fn run_gui(options: super::RunOptions) -> Result<()> {
     let recent_workspaces = options.settings.ui_recent_workspaces();
     let initial_recent = recent_workspaces.clone();
@@ -265,6 +270,8 @@ pub fn run_gui(options: super::RunOptions) -> Result<()> {
             {
                 crate::macos::set_dock_icon();
             }
+
+            single_instance::listen(app.handle().clone());
 
             // open initial repo, unless a deep link's already done so
             #[cfg(target_os = "macos")]
@@ -864,8 +871,24 @@ pub fn try_create_window(app_handle: &AppHandle, workspace: Option<PathBuf>) -> 
 
     let label = label_for_path(workspace.as_ref());
 
-    if let Some(existing) = app_handle.get_webview_window(&label) {
-        existing.set_focus()?;
+    if let Some(_existing) = app_handle.get_webview_window(&label) {
+        #[cfg(target_os = "macos")]
+        {
+            let handle = app_handle.clone();
+            let label = label.clone();
+            app_handle
+                .run_on_main_thread(move || {
+                    if let Some(w) = handle.get_webview_window(&label) {
+                        crate::macos::remove_move_to_active_space(&w.as_ref().window());
+                        crate::macos::activate_app();
+                        let _ = w.set_focus();
+                    }
+                })
+                .ok();
+        }
+        #[cfg(not(target_os = "macos"))]
+        _existing.set_focus()?;
+
         return Ok(());
     }
 
@@ -881,6 +904,20 @@ pub fn try_create_window(app_handle: &AppHandle, workspace: Option<PathBuf>) -> 
     .visible(false)
     .disable_drag_drop_handler()
     .build()?;
+
+    // NSWindow methods must run on the main thread; dispatch regardless of caller
+    #[cfg(target_os = "macos")]
+    {
+        let label = window.label().to_owned();
+        let handle = app_handle.clone();
+        app_handle
+            .run_on_main_thread(move || {
+                if let Some(w) = handle.get_webview_window(&label) {
+                    crate::macos::set_move_to_active_space(&w);
+                }
+            })
+            .ok();
+    }
 
     let app_state = app_handle.state::<AppState>();
     let settings = app_state.settings.clone();
@@ -1141,6 +1178,9 @@ fn handle_window_event(window: &Window, event: &WindowEvent) -> Result<()> {
         }
         WindowEvent::Focused(true) => {
             log::debug!("window focused; notifying frontend");
+
+            #[cfg(target_os = "macos")]
+            crate::macos::remove_move_to_active_space(window);
 
             let app_state = window.state::<AppState>();
 

--- a/src/gui/single_instance.rs
+++ b/src/gui/single_instance.rs
@@ -1,0 +1,87 @@
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+
+use interprocess::local_socket::{
+    GenericFilePath, ListenerOptions, Stream, ToFsName,
+    traits::{ListenerExt, Stream as _},
+};
+use tauri::AppHandle;
+
+fn socket_path() -> PathBuf {
+    std::env::temp_dir().join("gg-instance.sock")
+}
+
+/// Try to forward a workspace open request to an already-running GG instance.
+/// Returns true if another instance accepted the request (caller should exit).
+pub fn try_forward(workspace: Option<&PathBuf>) -> bool {
+    let path = socket_path();
+    let name = match path.to_fs_name::<GenericFilePath>() {
+        Ok(n) => n,
+        Err(_) => return false,
+    };
+
+    let stream = match Stream::connect(name) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    // resolve None to cwd here so the server opens the right directory
+    let resolved = workspace.cloned().or_else(|| std::env::current_dir().ok());
+    let line = match resolved {
+        Some(p) => format!("{}\n", p.display()),
+        None => "\n".to_string(),
+    };
+
+    let mut writer = &stream;
+    writer.write_all(line.as_bytes()).ok();
+    writer.flush().ok();
+    true
+}
+
+/// Start listening for forwarded open requests from subsequent GG launches.
+/// Silently returns if the socket cannot be bound (e.g. race with another instance).
+pub fn listen(app_handle: AppHandle) {
+    let path = socket_path();
+    let _ = std::fs::remove_file(&path); // clean up any stale socket
+
+    let name = match path.to_fs_name::<GenericFilePath>() {
+        Ok(n) => n,
+        Err(_) => return,
+    };
+
+    let listener = match ListenerOptions::new().name(name).create_sync() {
+        Ok(l) => l,
+        Err(e) => {
+            log::warn!("single-instance listener failed to bind: {e}");
+            return;
+        }
+    };
+
+    std::thread::spawn(move || {
+        for conn in listener.incoming() {
+            let stream = match conn {
+                Ok(s) => s,
+                Err(_) => break,
+            };
+
+            let app = app_handle.clone();
+            std::thread::spawn(move || {
+                let mut line = String::new();
+                BufReader::new(stream).read_line(&mut line).ok();
+                let workspace = {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(PathBuf::from(trimmed))
+                    }
+                };
+                tauri::async_runtime::spawn(async move {
+                    if let Err(e) = super::try_create_window(&app, workspace.clone()) {
+                        log::error!("single-instance open {:?}: {e}", workspace);
+                    }
+                });
+            });
+        }
+    });
+}

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,5 +1,7 @@
 use objc2::{AllocAnyThread, MainThreadMarker};
-use objc2_app_kit::{NSApplication, NSDocumentController, NSImage};
+use objc2_app_kit::{
+    NSApplication, NSDocumentController, NSImage, NSWindow, NSWindowCollectionBehavior,
+};
 use objc2_foundation::{NSData, NSString, NSURL};
 
 /// Used when run without an .app bundle.
@@ -25,6 +27,33 @@ pub fn set_dock_icon() {
     unsafe {
         app.setApplicationIconImage(Some(&icon));
     }
+}
+
+/// Ensure a newly created window appears on the active Space rather than
+/// switching to whichever Space GG was previously on.
+pub fn set_move_to_active_space(window: &tauri::WebviewWindow) {
+    let Ok(ptr) = window.ns_window() else { return };
+    let ns_win = unsafe { &*(ptr as *const NSWindow) };
+    let behavior = ns_win.collectionBehavior();
+    ns_win.setCollectionBehavior(behavior | NSWindowCollectionBehavior::MoveToActiveSpace);
+}
+
+pub fn remove_move_to_active_space(window: &tauri::Window) {
+    let Ok(ptr) = window.ns_window() else { return };
+    let ns_win = unsafe { &*(ptr as *const NSWindow) };
+    let behavior = ns_win.collectionBehavior();
+    ns_win.setCollectionBehavior(behavior & !NSWindowCollectionBehavior::MoveToActiveSpace);
+}
+
+pub fn activate_app() {
+    let Some(mtm) = MainThreadMarker::new() else {
+        log::error!("Cannot activate app: not on main thread");
+        return;
+    };
+
+    let app = NSApplication::sharedApplication(mtm);
+    #[allow(deprecated)]
+    app.activateIgnoringOtherApps(true);
 }
 
 /// add a workspace path to the macos "Recent Items" dock menu

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,9 +206,17 @@ fn spawn_app() -> Result<()> {
 fn run_app(args: Args) -> Result<()> {
     let (settings, _, _, _) = read_config(args.workspace().as_deref())?;
     let mode = args.mode().unwrap_or_else(|| default_mode(&settings));
-    let context = tauri::generate_context!();
 
     let is_child = std::env::var_os("GG_SPAWNED").is_some();
+
+    if matches!(mode, LaunchMode::Gui) && gui::try_forward_to_instance(args.workspace().as_ref()) {
+        if is_child {
+            println!("Startup complete.");
+        }
+        return Ok(());
+    }
+
+    let context = tauri::generate_context!();
 
     let options = RunOptions {
         context,


### PR DESCRIPTION
Adds a standard Window menu to the macOS menu bar that lists all open GG windows by repository name. The menu rebuilds whenever a window finishes loading a repo or is closed. Clicking an menu entry focuses that window.

<img width="124" height="137" alt="image" src="https://github.com/user-attachments/assets/df490954-006c-4d01-ae95-a9b01d1dbc10" />
