### PR TITLE
Add copy path button to changed file rows

### DIFF
--- a/app/objects/ChangeObject.svelte
+++ b/app/objects/ChangeObject.svelte
@@ -75,18 +75,22 @@
     <Zone {operand} let:target>
         <div class="layout" class:target>
             <Icon name={icon} state={context ? null : state} />
+            <span class="path">{hint ?? change.path.relative_path}</span>
             <ActionLink tip="copy path" onClick={onCopyPath}>
                 <Icon name="copy" />
             </ActionLink>
-            <span>{hint ?? change.path.relative_path}</span>
             {#if hasMergeTool && change.has_conflict && operand}
-                <ActionWidget tip="resolve in merge tool" onClick={onExternalResolve}>
-                    <Icon name="external-link" /> Resolve
-                </ActionWidget>
+                <div class="push-right">
+                    <ActionWidget tip="resolve in merge tool" onClick={onExternalResolve}>
+                        <Icon name="external-link" /> Resolve
+                    </ActionWidget>
+                </div>
             {:else if hasDiffTool && operand}
-                <ActionLink tip="open in diff tool" onClick={onExternalDiff}>
-                    <Icon name="external-link" />
-                </ActionLink>
+                <div class="push-right">
+                    <ActionLink tip="open in diff tool" onClick={onExternalDiff}>
+                        <Icon name="external-link" />
+                    </ActionLink>
+                </div>
             {/if}
         </div>
     </Zone>
@@ -101,8 +105,18 @@
         padding-left: 3px;
     }
 
-    .layout span {
-        flex: 1;
+    .layout .path {
+        min-width: 0;
+        flex: 0 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .push-right {
+        display: flex;
+        align-items: center;
+        margin-left: auto;
     }
 
     .layout.target {

--- a/app/objects/ChangeObject.svelte
+++ b/app/objects/ChangeObject.svelte
@@ -57,6 +57,10 @@
             path: change.path,
         });
     }
+
+    function onCopyPath() {
+        navigator.clipboard.writeText(change.path.relative_path);
+    }
 </script>
 
 <Object
@@ -71,6 +75,9 @@
     <Zone {operand} let:target>
         <div class="layout" class:target>
             <Icon name={icon} state={context ? null : state} />
+            <ActionLink tip="copy path" onClick={onCopyPath}>
+                <Icon name="copy" />
+            </ActionLink>
             <span>{hint ?? change.path.relative_path}</span>
             {#if hasMergeTool && change.has_conflict && operand}
                 <ActionWidget tip="resolve in merge tool" onClick={onExternalResolve}>

--- a/app/objects/ChangeObject.test.ts
+++ b/app/objects/ChangeObject.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from "vitest";
+import { render } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import { setupMocks, cleanupMocks } from "../mocks";
+import type { RevChange } from "../messages/RevChange";
+
+let mockChange: RevChange = {
+    kind: "Modified",
+    path: { repo_path: "some/dir/file.txt", relative_path: "some/dir/file.txt" },
+    has_conflict: false,
+    hunks: [],
+};
+
+describe("ChangeObject", () => {
+    let writeText: MockInstance;
+
+    beforeEach(() => {
+        setupMocks();
+        writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
+    });
+
+    afterEach(async () => {
+        writeText.mockRestore();
+        await cleanupMocks();
+    });
+
+    it("renders the file path and a copy path button", async () => {
+        const { default: ChangeObject } = await import("./ChangeObject.svelte");
+
+        const { container } = render(ChangeObject, {
+            props: { headers: null, change: mockChange, selected: false },
+        });
+
+        expect(container.textContent).toContain("some/dir/file.txt");
+        expect(container.querySelector("button[title='copy path']")).not.toBeNull();
+    });
+
+    it("clicking the copy path button copies the relative path", async () => {
+        const { default: ChangeObject } = await import("./ChangeObject.svelte");
+
+        const { container } = render(ChangeObject, {
+            props: { headers: null, change: mockChange, selected: false },
+        });
+
+        let button = container.querySelector<HTMLButtonElement>("button[title='copy path']");
+        button?.click();
+
+        expect(writeText).toHaveBeenCalledExactlyOnceWith("some/dir/file.txt");
+    });
+
+    it("clicking the copy path button does not select the change", async () => {
+        const { default: ChangeObject } = await import("./ChangeObject.svelte");
+        const { changeSelectEvent } = await import("../stores");
+
+        const { container } = render(ChangeObject, {
+            props: { headers: null, change: mockChange, selected: false },
+        });
+
+        let button = container.querySelector<HTMLButtonElement>("button[title='copy path']");
+        button?.click();
+
+        expect(get(changeSelectEvent)).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Adds a small copy button to each file row in the revision detail's change list, letting you copy a changed file's path to the clipboard without opening a shell or an external diff tool.

The button sits immediately to the right of the filename. When the row is too narrow to fit the whole path, the path truncates with an ellipsis and the copy button stays pinned to the right edge of the row, so it's always reachable.

<img width="470" height="142" alt="after" src="https://github.com/user-attachments/assets/e37bb250-95a5-4ecd-93e1-35558d9a2caa" />
