### PR TITLE
fix context menus on wayland

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,7 @@ dependencies = [
  "etcetera",
  "futures-util",
  "gix",
+ "gtk",
  "http-body-util",
  "humantime",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,10 @@ webbrowser = { version = "1", features = ["hardened"] }
 interprocess = "2"
 uuid = { version = "1", features = ["v4"] }
 
+[target."cfg(target_os = \"linux\")".dependencies]
+# must track tauri's gtk, which we borrow widgets from to place context menus
+gtk = "0.18"
+
 [target."cfg(windows)".dependencies]
 windows = { version = "0.61", features = [
     "Win32_Foundation",

--- a/app/controls/ContextMenu.test.ts
+++ b/app/controls/ContextMenu.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render } from "@testing-library/svelte";
 import { setupMocks, cleanupMocks } from "../mocks";
+import { wait } from "../ipc";
 import type { RevHeader } from "../messages/RevHeader";
 import type { Operand } from "../messages/Operand";
 
@@ -25,7 +26,7 @@ describe("ContextMenu (revert)", () => {
     beforeEach(() => {
         mutationCalls = [];
         setupMocks((cmd, args) => {
-            if (cmd === "backout_revisions") {
+            if (cmd === "backout_revisions" || cmd === "create_ref") {
                 mutationCalls.push({ cmd, args });
                 return {
                     type: "Updated",
@@ -99,6 +100,104 @@ describe("ContextMenu (revert)", () => {
 
         expect(revertButton).toBeTruthy();
         expect(revertButton!.disabled).toBe(false);
+    });
+
+    it("clicking 'Create bookmark...' calls create_ref with the entered name", async () => {
+        const { default: ContextMenu } = await import("./ContextMenu.svelte");
+        const { selectionHeaders, currentInput } = await import("../stores");
+        const { get } = await import("svelte/store");
+        selectionHeaders.set([mockHeader]);
+
+        let onClose = vi.fn();
+        let operand: Operand = { type: "Revision", header: mockHeader };
+
+        const { container } = render(ContextMenu, {
+            props: { operand, x: 100, y: 100, onClose },
+        });
+
+        let buttons = container.querySelectorAll("button");
+        let bookmarkButton = Array.from(buttons).find((b) => b.textContent === "Create bookmark...");
+
+        expect(bookmarkButton).toBeTruthy();
+        expect(bookmarkButton!.disabled).toBe(false);
+
+        bookmarkButton!.click();
+
+        expect(onClose).toHaveBeenCalled();
+
+        // the name is collected by a modal before anything is sent to the backend
+        await vi.waitFor(() => {
+            expect(get(currentInput)).toBeTruthy();
+        });
+
+        let request = get(currentInput)!;
+        expect(request.title).toBe("Create Bookmark");
+        expect(request.fields.map((f) => f.label)).toEqual(["Bookmark Name"]);
+
+        request.callback({ fields: { "Bookmark Name": "my-bookmark" } });
+
+        await vi.waitFor(() => {
+            expect(mutationCalls).toHaveLength(1);
+        });
+
+        expect(mutationCalls[0].cmd).toBe("create_ref");
+        let mutation = (mutationCalls[0].args as any).mutation;
+        expect(mutation.id).toEqual(mockHeader.id);
+        expect(mutation.ref.type).toBe("LocalBookmark");
+        expect(mutation.ref.bookmark_name).toBe("my-bookmark");
+    });
+
+    it("dismissing the bookmark dialog sends no mutation", async () => {
+        const { default: ContextMenu } = await import("./ContextMenu.svelte");
+        const { selectionHeaders, currentInput } = await import("../stores");
+        const { get } = await import("svelte/store");
+        selectionHeaders.set([mockHeader]);
+
+        let operand: Operand = { type: "Revision", header: mockHeader };
+
+        const { container } = render(ContextMenu, {
+            props: { operand, x: 100, y: 100, onClose: () => { } },
+        });
+
+        let buttons = container.querySelectorAll("button");
+        let bookmarkButton = Array.from(buttons).find((b) => b.textContent === "Create bookmark...");
+
+        bookmarkButton!.click();
+
+        await vi.waitFor(() => {
+            expect(get(currentInput)).toBeTruthy();
+        });
+
+        get(currentInput)!.callback(null);
+
+        await wait();
+        expect(mutationCalls).toHaveLength(0);
+    });
+
+    it("create bookmark is disabled for multi-revision selection", async () => {
+        const { default: ContextMenu } = await import("./ContextMenu.svelte");
+        const { selectionHeaders } = await import("../stores");
+
+        let secondHeader = {
+            ...mockHeader,
+            id: {
+                change: { type: "ChangeId" as const, hex: "xyz789", prefix: "xyz", rest: "789", offset: null, is_divergent: false },
+                commit: { type: "CommitId" as const, hex: "uvw012", prefix: "uvw", rest: "012" },
+            },
+        };
+        selectionHeaders.set([mockHeader, secondHeader]);
+
+        let operand: Operand = { type: "Revisions", headers: [mockHeader, secondHeader] };
+
+        const { container } = render(ContextMenu, {
+            props: { operand, x: 100, y: 100, onClose: () => { } },
+        });
+
+        let buttons = container.querySelectorAll("button");
+        let bookmarkButton = Array.from(buttons).find((b) => b.textContent === "Create bookmark...");
+
+        expect(bookmarkButton).toBeTruthy();
+        expect(bookmarkButton!.disabled).toBe(true);
     });
 
     it("revert is enabled for multi-revision selection", async () => {

--- a/app/objects/Object.svelte
+++ b/app/objects/Object.svelte
@@ -63,10 +63,15 @@ Core component for direct-manipulation objects. A drag&drop source.
             let effectiveOperand = getEffectiveOperand();
             currentContext.set(effectiveOperand);
 
+            // the backend can't ask wayland where the pointer is, so it has to be told
+            let mouseEvent = event as MouseEvent;
             if (isTauri()) {
-                trigger("forward_context_menu", { context: effectiveOperand });
+                trigger("forward_context_menu", {
+                    context: effectiveOperand,
+                    x: mouseEvent.clientX,
+                    y: mouseEvent.clientY,
+                });
             } else {
-                const mouseEvent = event as MouseEvent;
                 hasMenu.set({ x: mouseEvent.clientX, y: mouseEvent.clientY });
             }
         }

--- a/src/gui/menu.rs
+++ b/src/gui/menu.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, anyhow};
 #[cfg(target_os = "macos")]
 use tauri::menu::AboutMetadata;
 use tauri::{
-    AppHandle, Emitter, EventTarget, Manager, Window, Wry,
+    AppHandle, Emitter, EventTarget, LogicalPosition, Manager, Window, Wry,
     menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu},
 };
 use tauri_plugin_dialog::{DialogExt, FilePath};
@@ -439,8 +439,57 @@ pub fn handle_selection(
 }
 
 // enables context menu items for a revision and shows the menu
-pub fn handle_context(window: Window, ctx: Operand, ignore_immutable: bool) -> Result<()> {
+pub fn handle_context(
+    window: Window,
+    ctx: Operand,
+    ignore_immutable: bool,
+    position: LogicalPosition<f64>,
+) -> Result<()> {
     log::debug!("handling context {ctx:?}");
+
+    // gtk widgets are main-thread-only and popup_context measures them, so queue the
+    // whole popup instead of touching them from whichever thread handles the command
+    let target = window.clone();
+    window.run_on_main_thread(move || {
+        if let Err(err) = popup_context(&target, ctx, ignore_immutable, position) {
+            log::error!("failed to show context menu: {err:#}");
+        }
+    })?;
+
+    Ok(())
+}
+
+// anchors the popup at a point given in webview coordinates. muda positions menus
+// against the toplevel gdk window; on wayland gtk draws client-side decorations into
+// that window, so without this the menu lands offset by the titlebar and shadow
+#[cfg(target_os = "linux")]
+fn to_window_position(window: &Window, position: LogicalPosition<f64>) -> LogicalPosition<f64> {
+    use gtk::prelude::WidgetExt;
+
+    match window
+        .default_vbox()
+        .ok()
+        .zip(window.gtk_window().ok())
+        .and_then(|(vbox, gtk_window)| vbox.translate_coordinates(&gtk_window, 0, 0))
+    {
+        Some((dx, dy)) => LogicalPosition::new(position.x + dx as f64, position.y + dy as f64),
+        None => position,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn to_window_position(_window: &Window, position: LogicalPosition<f64>) -> LogicalPosition<f64> {
+    position
+}
+
+fn popup_context(
+    window: &Window,
+    ctx: Operand,
+    ignore_immutable: bool,
+    position: LogicalPosition<f64>,
+) -> Result<()> {
+    let anchor = to_window_position(window, position);
+    log::debug!("popping context menu at {position:?} -> {anchor:?}");
 
     let state = window.state::<AppState>();
     let guard = state.windows.lock().expect("state mutex poisoned");
@@ -463,7 +512,7 @@ pub fn handle_context(window: Window, ctx: Operand, ignore_immutable: bool) -> R
             context_menu.enable("revision_restore", state.restore)?;
             context_menu.enable("revision_bookmark", state.bookmark)?;
 
-            window.popup_menu(context_menu)?;
+            window.popup_menu_at(context_menu, anchor)?;
         }
         Operand::Revisions { headers } => {
             let context_menu = &guard
@@ -482,7 +531,7 @@ pub fn handle_context(window: Window, ctx: Operand, ignore_immutable: bool) -> R
             context_menu.enable("revision_restore", state.restore)?;
             context_menu.enable("revision_bookmark", state.bookmark)?;
 
-            window.popup_menu(context_menu)?;
+            window.popup_menu_at(context_menu, anchor)?;
         }
         Operand::Change { headers, .. } => {
             let context_menu = &guard
@@ -507,7 +556,7 @@ pub fn handle_context(window: Window, ctx: Operand, ignore_immutable: bool) -> R
                         .is_some_and(|header| header.parent_ids.len() == 1),
             )?;
 
-            window.popup_menu(context_menu)?;
+            window.popup_menu_at(context_menu, anchor)?;
         }
         Operand::Ref { r#ref, .. } => {
             let context_menu = &guard
@@ -584,7 +633,7 @@ pub fn handle_context(window: Window, ctx: Operand, ignore_immutable: bool) -> R
                 ),
             )?;
 
-            window.popup_menu(context_menu)?;
+            window.popup_menu_at(context_menu, anchor)?;
         }
         Operand::Workspace { .. } => {
             let context_menu = &guard
@@ -592,7 +641,7 @@ pub fn handle_context(window: Window, ctx: Operand, ignore_immutable: bool) -> R
                 .expect("session not found")
                 .workspace_menu;
 
-            window.popup_menu(context_menu)?;
+            window.popup_menu_at(context_menu, anchor)?;
         }
         _ => (), // no popup required
     };
@@ -604,7 +653,8 @@ pub fn handle_event(window: &Window, event: MenuEvent) -> Result<()> {
     log::debug!("handling event {event:?}");
 
     // we use a shared menu due to cleanup issues
-    if !window.is_focused()? {
+    if !window.state::<AppState>().owns_menu_events(window)? {
+        log::debug!("ignoring event for unfocused window {}", window.label());
         return Ok(());
     }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -19,7 +19,10 @@ use tauri::async_runtime;
 use tauri::ipc::InvokeError;
 use tauri::menu::Menu;
 use tauri::webview::WebviewWindowBuilder;
-use tauri::{AppHandle, Emitter, EventTarget, Listener, Manager, State, Window, WindowEvent, Wry};
+use tauri::{
+    AppHandle, Emitter, EventTarget, Listener, LogicalPosition, Manager, State, Window,
+    WindowEvent, Wry,
+};
 use tauri_plugin_window_state::StateFlags;
 
 use gg_lib::config::GGSettings;
@@ -39,6 +42,10 @@ use sink::TauriSink;
 
 struct AppState {
     windows: Arc<Mutex<HashMap<String, WindowState>>>,
+    // menus are shared between windows, so events have to be routed to one of them. this
+    // can't be is_focused(), because a wayland popup grab takes focus off the toplevel for
+    // as long as the menu is open - exactly when we need to know who opened it
+    last_focused: Arc<Mutex<Option<String>>>,
     settings: UserSettings,
     initial_ignore_immutable: bool,
     enable_askpass: bool,
@@ -48,10 +55,21 @@ impl AppState {
     fn new(settings: UserSettings, initial_ignore_immutable: bool, enable_askpass: bool) -> Self {
         Self {
             windows: Arc::new(Mutex::new(HashMap::new())),
+            last_focused: Arc::new(Mutex::new(None)),
             settings,
             initial_ignore_immutable,
             enable_askpass,
         }
+    }
+
+    // the window that most recently gained focus, ignoring transient losses to menus
+    fn owns_menu_events(&self, window: &Window) -> Result<bool> {
+        Ok(
+            match &*self.last_focused.lock().expect("state mutex poisoned") {
+                Some(label) => label == window.label(),
+                None => window.is_focused()?,
+            },
+        )
     }
 }
 
@@ -310,6 +328,8 @@ fn forward_context_menu(
     window: Window,
     app_state: State<AppState>,
     context: messages::Operand,
+    x: f64,
+    y: f64,
 ) -> Result<(), InvokeError> {
     let ignore_immutable = {
         let guard = app_state.windows.lock().expect("state mutex poisoned");
@@ -318,7 +338,13 @@ fn forward_context_menu(
             .map(|s| s.ignore_immutable)
             .unwrap_or(false)
     };
-    menu::handle_context(window, context, ignore_immutable).map_err(InvokeError::from_anyhow)?;
+    menu::handle_context(
+        window,
+        context,
+        ignore_immutable,
+        LogicalPosition::new(x, y),
+    )
+    .map_err(InvokeError::from_anyhow)?;
     Ok(())
 }
 
@@ -1079,11 +1105,19 @@ fn handle_window_event(window: &Window, event: &WindowEvent) -> Result<()> {
         WindowEvent::Destroyed => {
             let app_state = window.state::<AppState>();
             app_state.windows.lock().unwrap().remove(window.label());
+
+            let mut last_focused = app_state.last_focused.lock().unwrap();
+            if last_focused.as_deref() == Some(window.label()) {
+                *last_focused = None;
+            }
         }
         WindowEvent::Focused(true) => {
             log::debug!("window focused; notifying frontend");
 
             let app_state = window.state::<AppState>();
+
+            *app_state.last_focused.lock().expect("state mutex poisoned") =
+                Some(window.label().to_owned());
 
             let (session_tx, selection, ignore_immutable) = {
                 let guard = app_state.windows.lock().expect("state mutex poisoned");


### PR DESCRIPTION
Right-clicking a change under a Wayland compositor pops the context menu up detached from the thing that was clicked, and none of its commands do anything. Reproduced on COSMIC; the cause isn't compositor-specific, so GNOME and KDE under Wayland should behave the same way. X11, macOS and Windows are unaffected.

<img width="2530" height="1470" alt="Screenshot_2026-07-25_22-08-33" src="https://github.com/user-attachments/assets/3d3f3519-8b80-4789-afd2-e30383827b75" />

## Cause

Two separate failures that present identically.

**Positioning.** `window.popup_menu()` passes `position: None` to muda, which takes its pointer-position branch (`muda-0.19.1/src/platform_impl/gtk/mod.rs:1428`):

```rust
let window = widget.screen().and_then(|s| s.root_window());
let pos = ...default_seat().pointer().position();
gtk_menu.popup_at_rect(&window, &Rectangle::new(pos.0, pos.1, 0, 0), ...);
```

Both of those are X11 assumptions. `root_window()` isn't a real surface on Wayland, so GDK can't parent an `xdg_popup` and maps the menu as a free-floating toplevel — visible in the log as `Couldn't map as window ... as popup because it doesn't have a parent`. And Wayland never reports a global pointer position, so the coordinates are meaningless anyway.

**Activation.** Because the menu was a plain toplevel rather than a popup, it never took an implicit grab, so item activation was never delivered. Fixing the positioning turns it into a real popup which *does* grab — and that moves keyboard focus off the toplevel for as long as the menu is open. `handle_event` opened with `if !window.is_focused()? { return Ok(()); }`, so it then silently dropped every command instead. Same symptom, second mechanism.

## Fix

Use muda's other branch (`position: Some(..)`), which anchors against `widget.window()` — a real surface. The click position is sent from the webview, since the backend can't ask Wayland where the pointer is.

Webview coordinates are relative to the content area, but muda anchors against the *toplevel* GDK window, and GTK3 draws client-side decorations into that window on Wayland. `to_window_position()` measures that offset via `translate_coordinates(vbox → gtk_window)` rather than hardcoding it, so it stays correct when the window is maximised and the shadow margin disappears. It's a no-op on X11 and compiled out on other platforms.

The focus check existed to disambiguate which window handles a shared menu, so rather than dropping it, menu events now route by the last window to *gain* focus. Ignoring transient losses keeps the multi-window behaviour while making a popup grab unable to corrupt the routing. This should also fix the menubar on Wayland, which had the same exposure.

`gtk` is added as a direct dependency because Tauri doesn't re-export it; Cargo unifies it with Tauri's own `gtk 0.18.2`.

## Testing

The first commit adds coverage for the create-bookmark context menu command — name entry reaching `create_ref`, dismissal sending nothing, and the singleton-only enablement rule.

Worth being explicit about what that does and doesn't buy: those tests drive `ContextMenu.svelte`, the HTML menu used in web mode. They pin the dialog and mutation wiring, but they do **not** cover the native GTK path this PR changes, and would not have caught this bug — it needs a real compositor. The tests are ordered first and pass independently of the fix, so each commit is green on its own.

Verified: `cargo build`, `cargo fmt`, `cargo clippy` (only a pre-existing warning in `src/worker/mutations/ref.rs:428`), frontend suite 17/17, `svelte-check` clean. `cargo test` is 181 passed / 2 failed, but those two (`snapshot_respects_xdg_gitignore_*`) fail identically on the base commit and are environment-related.
