### PR TITLE
build: Ignore config files for Mise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ dist-ssr
 # Agent config
 .claude/settings.local.json
 .mcp.json
+
+# Environment managers
+mise.local.toml


### PR DESCRIPTION
Mise (https://mise.jdx.dev) records configuration information in mise.local.toml. Ignore it to prevent inadvertent commits.